### PR TITLE
removed delete button for students

### DIFF
--- a/src/main/resources/templates/project-details.html
+++ b/src/main/resources/templates/project-details.html
@@ -25,7 +25,7 @@
             <button type="submit" class="btn btn-secondary">Archive</button>
         </form>
 
-        <form th:action="@{/projects/delete}" method="post" class="d-inline">
+        <form th:action="@{/projects/delete}" method="post" class="d-inline" th:if="${!currentUserIsStudent}">
             <input type="hidden" name="id" th:value="${project.id}"/>
             <button type="submit" class="btn btn-danger"
                     onclick="return confirm('Are you sure you want to delete this project?');">Delete</button>


### PR DESCRIPTION
Students can no longer delete projects. Should still be good for when coordinator is added, as it only removes the option if you are a student. I think coordinators should be able to delete projects. Will close issue #52 