### PR TITLE
53 login header live updates

### DIFF
--- a/src/main/java/vv/pms/project/Project.java
+++ b/src/main/java/vv/pms/project/Project.java
@@ -54,7 +54,7 @@ public class Project {
     }
 
     public void setId(long id) {
-        this.id = id;
+        this.id = (Long) id;
     }
 
     public String getTitle() {

--- a/src/main/java/vv/pms/ui/CurrentUserAdvice.java
+++ b/src/main/java/vv/pms/ui/CurrentUserAdvice.java
@@ -3,15 +3,42 @@ package vv.pms.ui;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import vv.pms.student.StudentService;
+import vv.pms.professor.ProfessorService;
 
 @ControllerAdvice
 public class CurrentUserAdvice {
 
+    private final StudentService studentService;
+    private final ProfessorService professorService;
+
+    public CurrentUserAdvice(StudentService studentService, ProfessorService professorService) {
+        this.studentService = studentService;
+        this.professorService = professorService;
+    }
+
     @ModelAttribute("currentUserName")
     public String currentUserName(HttpSession session) {
         if (session == null) return null;
-        Object o = session.getAttribute("currentUserName");
-        return o == null ? null : o.toString();
+
+        Long id = (Long) session.getAttribute("currentUserId");
+        String role = (String) session.getAttribute("currentUserRole");
+
+        if (id == null || role == null) return null;
+
+        if ("STUDENT".equalsIgnoreCase(role)) {
+            return studentService.findStudentById(id)
+                    .map(s -> s.getName())
+                    .orElse(null);
+        }
+
+        if ("PROFESSOR".equalsIgnoreCase(role)) {
+            return professorService.findProfessorById(id)
+                    .map(p -> p.getName())
+                    .orElse(null);
+        }
+
+        return null;
     }
 
     @ModelAttribute("currentUserRole")
@@ -21,3 +48,4 @@ public class CurrentUserAdvice {
         return o == null ? null : o.toString();
     }
 }
+


### PR DESCRIPTION
CLOSES: #53 

Previously, the header relied only on the value stored in the session (currentUserName).
When a user edited their profile, this session value didn’t change until logout → login, causing the header to display outdated information.

What Changed:

Replaced session-based name resolution with a DB lookup using currentUserId and currentUserRole.
Updated CurrentUserAdvice to fetch the latest user name each request dynamically.
Ensures the header always displays the correct name immediately after profile edits, without needing a new session. May require tab refresh

Files Updated
- CurrentUserAdvice.java

Added logic:
If role == STUDENT: fetch from StudentService
If role == PROFESSOR: fetch from ProfessorService

