### PR TITLE
Fix header not updating for Coordinator role

### DIFF
--- a/src/main/java/vv/pms/ui/CoordinatorController.java
+++ b/src/main/java/vv/pms/ui/CoordinatorController.java
@@ -43,6 +43,9 @@ public class CoordinatorController {
             return "redirect:/login";
         }
 
+        model.addAttribute("currentUserName", session.getAttribute("currentUserName"));
+        model.addAttribute("currentUserRole", session.getAttribute("currentUserRole"));
+
         List<Student> allStudents = studentService.findAllStudents();
         List<Project> allProjects = projectService.getAllProjects();
 


### PR DESCRIPTION
Fix: Header Not Updating for Coordinator Role

Summary
This PR fixes an issue where the header continued to show "Log in / Sign up" for Coordinators after login. Student and Professor flows worked correctly because their controllers implicitly added the necessary header attributes to the model, while the Coordinator controller did not.

Root Cause
- Login correctly stores user information in session (currentUserName, currentUserRole, etc.)
- The header fragment reads these values from the model, not the session
- CoordinatorController never added these values into the model
- This caused the header to evaluate the Coordinator as "not logged in"

Fix Implemented
- Added the required attributes to CoordinatorController:

model.addAttribute("currentUserName", session.getAttribute("currentUserName"));
model.addAttribute("currentUserRole", session.getAttribute("currentUserRole"));

