### PR TITLE
feat: add coordinator presentation management + room assignment workflow

### DIFF
--- a/src/main/java/vv/pms/presentation/PresentationService.java
+++ b/src/main/java/vv/pms/presentation/PresentationService.java
@@ -1,0 +1,348 @@
+package vv.pms.presentation;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import vv.pms.availability.Availability;
+import vv.pms.availability.AvailabilityService;
+import vv.pms.allocation.AllocationService;
+import vv.pms.allocation.ProjectAllocation;
+import vv.pms.presentation.internal.PresentationSlotRepository;
+import vv.pms.presentation.internal.RoomRepository;
+import vv.pms.professor.Professor;
+import vv.pms.professor.ProfessorService;
+import vv.pms.project.Project;
+import vv.pms.project.ProjectService;
+import vv.pms.student.Student;
+import vv.pms.student.StudentService;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class PresentationService {
+
+    private final RoomRepository roomRepository;
+    private final PresentationSlotRepository slotRepository;
+    private final AvailabilityService availabilityService;
+    private final AllocationService allocationService;
+    private final ProjectService projectService;
+    private final ProfessorService professorService;
+    private final StudentService studentService;
+
+    // 5 days, 16 bins of 30 minutes (8:00–16:00)
+    private static final int DAYS = 5;
+    private static final int BINS = 16;
+    private static final int DURATION_BINS = 1; // 30 minutes
+
+    private static final String[] DAY_NAMES = {
+            "Monday", "Tuesday", "Wednesday", "Thursday", "Friday"
+    };
+
+    public record SlotOption(int dayIndex, int startBinIndex, String label) {}
+
+    public record PresentationRow(
+            Long projectId,
+            String projectTitle,
+            String professorName,
+            String studentNames,
+            Long roomId,
+            String slotLabel
+    ) {}
+
+    public PresentationService(RoomRepository roomRepository,
+                               PresentationSlotRepository slotRepository,
+                               AvailabilityService availabilityService,
+                               AllocationService allocationService,
+                               ProjectService projectService,
+                               ProfessorService professorService,
+                               StudentService studentService) {
+        this.roomRepository = roomRepository;
+        this.slotRepository = slotRepository;
+        this.availabilityService = availabilityService;
+        this.allocationService = allocationService;
+        this.projectService = projectService;
+        this.professorService = professorService;
+        this.studentService = studentService;
+    }
+
+    // -----------------------------
+    // Room helpers (used by controller or RoomService)
+    // -----------------------------
+    @Transactional(readOnly = true)
+    public List<Room> getAllRooms() {
+        return roomRepository.findAll();
+    }
+
+    // -----------------------------
+    // Presentation assignment
+    // -----------------------------
+    public PresentationSlot assignPresentation(Long projectId,
+                                               Long roomId,
+                                               int dayIndex,
+                                               int startBinIndex) {
+
+        if (dayIndex < 0 || dayIndex >= DAYS) {
+            throw new IllegalArgumentException("Invalid day index: " + dayIndex);
+        }
+        if (startBinIndex < 0 || startBinIndex >= BINS) {
+            throw new IllegalArgumentException("Invalid start-bin index: " + startBinIndex);
+        }
+
+        Project project = projectService.findProjectById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("Project " + projectId + " not found"));
+
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("Room " + roomId + " not found"));
+
+        if (hasRoomConflict(roomId, dayIndex, startBinIndex, DURATION_BINS, projectId)) {
+            throw new IllegalStateException("Room is already booked at that time.");
+        }
+
+        PresentationSlot slot = slotRepository.findByProjectId(projectId)
+                .orElseGet(PresentationSlot::new);
+
+        slot.setProjectId(project.getId());
+        slot.setRoomId(room.getId());
+        slot.setDayIndex(dayIndex);
+        slot.setStartBinIndex(startBinIndex);
+        slot.setDurationBins(DURATION_BINS);
+
+        return slotRepository.save(slot);
+    }
+
+    public void unassignPresentation(Long projectId) {
+        slotRepository.findByProjectId(projectId).ifPresent(slotRepository::delete);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<PresentationSlot> findByProjectId(Long projectId) {
+        return slotRepository.findByProjectId(projectId);
+    }
+
+    // -----------------------------
+    // Available slots for a project + room
+    // -----------------------------
+    @Transactional(readOnly = true)
+    public List<SlotOption> getAvailableSlots(Long projectId, Long roomId) {
+        ProjectAllocation allocation = allocationService.findAllocationByProjectId(projectId).orElse(null);
+        if (allocation == null || allocation.getAssignedStudentIds().isEmpty()) {
+            return List.of();
+        }
+
+        Room room = roomRepository.findById(roomId).orElse(null);
+        if (room == null) {
+            return List.of();
+        }
+        Boolean[][] roomAvail = normalize(room.getAvailability());
+
+        Long professorId = allocation.getProfessorId();
+        Professor prof = professorService.findProfessorById(professorId).orElse(null);
+        if (prof == null) {
+            return List.of();
+        }
+        Availability profAvailEntity = availabilityService.getAvailability(professorId, "PROFESSOR");
+        Boolean[][] profAvail = normalize(profAvailEntity.getTimeslots());
+
+        List<Long> studentIds = allocation.getAssignedStudentIds();
+        List<Boolean[][]> studentMatrices = new ArrayList<>();
+        for (Long sid : studentIds) {
+            Student s = studentService.findStudentById(sid).orElse(null);
+            if (s == null) continue;
+            Availability sAvailEntity = availabilityService.getAvailability(sid, "STUDENT");
+            studentMatrices.add(normalize(sAvailEntity.getTimeslots()));
+        }
+
+        boolean[][] intersection = new boolean[DAYS][BINS];
+        for (int d = 0; d < DAYS; d++) {
+            for (int t = 0; t < BINS; t++) {
+                boolean ok = bool(roomAvail[d][t]) && bool(profAvail[d][t]);
+                for (Boolean[][] sm : studentMatrices) {
+                    ok = ok && bool(sm[d][t]);
+                    if (!ok) break;
+                }
+                intersection[d][t] = ok;
+            }
+        }
+
+        Map<Integer, Set<Integer>> occupied = occupiedBinsForRoom(roomId, projectId);
+
+        List<SlotOption> result = new ArrayList<>();
+        for (int d = 0; d < DAYS; d++) {
+            for (int t = 0; t <= BINS - DURATION_BINS; t++) {
+                boolean blockOk = true;
+                for (int k = 0; k < DURATION_BINS; k++) {
+                    if (!intersection[d][t + k]) {
+                        blockOk = false;
+                        break;
+                    }
+                }
+                if (!blockOk) continue;
+                if (binRangeOverlaps(occupied, d, t, DURATION_BINS)) {
+                    continue;
+                }
+                String label = formatSlotLabel(d, t, DURATION_BINS);
+                result.add(new SlotOption(d, t, label));
+            }
+        }
+
+        return result.stream()
+                .sorted(Comparator.comparingInt(SlotOption::dayIndex)
+                        .thenComparingInt(SlotOption::startBinIndex))
+                .collect(Collectors.toList());
+    }
+
+    private Boolean[][] normalize(Boolean[][] src) {
+        Boolean[][] matrix = new Boolean[DAYS][BINS];
+        for (int d = 0; d < DAYS; d++) {
+            for (int t = 0; t < BINS; t++) {
+                Boolean v = (src != null && d < src.length && src[d] != null && t < src[d].length)
+                        ? src[d][t]
+                        : Boolean.FALSE;
+                matrix[d][t] = (v != null ? v : Boolean.FALSE);
+            }
+        }
+        return matrix;
+    }
+
+    private boolean bool(Boolean b) {
+        return b != null && b;
+    }
+
+    private Map<Integer, Set<Integer>> occupiedBinsForRoom(Long roomId, Long projectIdToIgnore) {
+        List<PresentationSlot> slots = slotRepository.findByRoomId(roomId);
+        Map<Integer, Set<Integer>> map = new HashMap<>();
+        for (PresentationSlot s : slots) {
+            if (projectIdToIgnore != null && projectIdToIgnore.equals(s.getProjectId())) {
+                continue;
+            }
+            int d = s.getDayIndex();
+            int start = s.getStartBinIndex();
+            int dur = s.getDurationBins();
+            Set<Integer> set = map.computeIfAbsent(d, k -> new HashSet<>());
+            for (int t = start; t < start + dur; t++) {
+                set.add(t);
+            }
+        }
+        return map;
+    }
+
+    private boolean binRangeOverlaps(Map<Integer, Set<Integer>> occupied,
+                                     int dayIndex,
+                                     int startBin,
+                                     int dur) {
+        Set<Integer> used = occupied.get(dayIndex);
+        if (used == null) return false;
+        for (int t = startBin; t < startBin + dur; t++) {
+            if (used.contains(t)) return true;
+        }
+        return false;
+    }
+
+    private String formatSlotLabel(int dayIndex, int startBinIndex, int durBins) {
+        String day = DAY_NAMES[dayIndex];
+        int startMinutes = 8 * 60 + startBinIndex * 30;
+        int endMinutes = startMinutes + durBins * 30;
+
+        return String.format(
+                "%s %02d:%02d-%02d:%02d",
+                day,
+                startMinutes / 60, startMinutes % 60,
+                endMinutes / 60, endMinutes % 60
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public String describeSlot(PresentationSlot slot) {
+        if (slot == null) return null;
+        return formatSlotLabel(slot.getDayIndex(), slot.getStartBinIndex(), slot.getDurationBins());
+    }
+
+    // -----------------------------
+    // Best-effort allocation
+    // -----------------------------
+    public void runBestEffortAllocation() {
+        List<Room> rooms = roomRepository.findAll();
+        if (rooms.isEmpty()) return;
+
+        List<ProjectAllocation> allocations = allocationService.findAllAllocations().stream()
+                .filter(a -> !a.getAssignedStudentIds().isEmpty())
+                .collect(Collectors.toList());
+
+        for (ProjectAllocation allocation : allocations) {
+            Long pid = allocation.getProjectId();
+            if (!projectService.findProjectById(pid).isPresent()) continue;
+            if (slotRepository.findByProjectId(pid).isPresent()) continue;
+
+            for (Room room : rooms) {
+                List<SlotOption> options = getAvailableSlots(pid, room.getId());
+                if (!options.isEmpty()) {
+                    SlotOption first = options.get(0);
+                    try {
+                        assignPresentation(pid, room.getId(), first.dayIndex(), first.startBinIndex());
+                        break;
+                    } catch (RuntimeException ignored) {
+                    }
+                }
+            }
+        }
+    }
+
+    // -----------------------------
+    // View model for /presentations
+    // -----------------------------
+    @Transactional(readOnly = true)
+    public List<PresentationRow> buildPresentationRows() {
+        List<ProjectAllocation> allocations = allocationService.findAllAllocations().stream()
+                .filter(a -> !a.getAssignedStudentIds().isEmpty())
+                .collect(Collectors.toList());
+
+        List<PresentationRow> rows = new ArrayList<>();
+
+        for (ProjectAllocation alloc : allocations) {
+            Long projectId = alloc.getProjectId();
+            Project project = projectService.findProjectById(projectId).orElse(null);
+            if (project == null) continue;
+
+            Professor prof = professorService.findProfessorById(alloc.getProfessorId()).orElse(null);
+            String profName = prof != null ? prof.getName() : "(unknown)";
+
+            List<Long> studentIds = alloc.getAssignedStudentIds();
+            String studentNames = studentIds.stream()
+                    .map(id -> studentService.findStudentById(id).orElse(null))
+                    .filter(Objects::nonNull)
+                    .map(Student::getName)
+                    .collect(Collectors.joining(", "));
+
+            PresentationSlot slot = slotRepository.findByProjectId(projectId).orElse(null);
+            Long roomId = slot != null ? slot.getRoomId() : null;
+            String slotLabel = describeSlot(slot);
+
+            rows.add(new PresentationRow(
+                    projectId,
+                    project.getTitle(),
+                    profName,
+                    studentNames,
+                    roomId,
+                    slotLabel
+            ));
+        }
+
+        return rows;
+    }
+
+    private boolean hasRoomConflict(Long roomId, int dayIndex, int startBinIndex, int durationBins, Long projectIdToIgnore) {
+        Map<Integer, Set<Integer>> occupied = occupiedBinsForRoom(roomId, projectIdToIgnore);
+
+        Set<Integer> used = occupied.get(dayIndex);
+        if (used == null) return false;
+
+        for (int t = startBinIndex; t < startBinIndex + durationBins; t++) {
+            if (used.contains(t)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/vv/pms/presentation/PresentationSlot.java
+++ b/src/main/java/vv/pms/presentation/PresentationSlot.java
@@ -1,0 +1,56 @@
+package vv.pms.presentation;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "presentation_slots",
+        uniqueConstraints = @UniqueConstraint(columnNames = "projectId"))
+public class PresentationSlot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // One presentation per project
+    @Column(nullable = false, unique = true)
+    private Long projectId;
+
+    @Column(nullable = false)
+    private Long roomId;
+
+    // 0-4 = Mon-Fri
+    @Column(nullable = false)
+    private int dayIndex;
+
+    // 0-15 = 30-min bins from 08:00
+    @Column(nullable = false)
+    private int startBinIndex;
+
+    // 1 = 30 minutes
+    @Column(nullable = false)
+    private int durationBins = 1;
+
+    public PresentationSlot() {}
+
+    public PresentationSlot(Long projectId, Long roomId, int dayIndex, int startBinIndex, int durationBins) {
+        this.projectId = projectId;
+        this.roomId = roomId;
+        this.dayIndex = dayIndex;
+        this.startBinIndex = startBinIndex;
+        this.durationBins = durationBins;
+    }
+
+    public Long getId() { return id; }
+    public Long getProjectId() { return projectId; }
+    public Long getRoomId() { return roomId; }
+    public int getDayIndex() { return dayIndex; }
+    public int getStartBinIndex() { return startBinIndex; }
+    public int getDurationBins() { return durationBins; }
+
+    public void setId(Long id) { this.id = id; }
+    public void setProjectId(Long projectId) { this.projectId = projectId; }
+    public void setRoomId(Long roomId) { this.roomId = roomId; }
+    public void setDayIndex(int dayIndex) { this.dayIndex = dayIndex; }
+    public void setStartBinIndex(int startBinIndex) { this.startBinIndex = startBinIndex; }
+    public void setDurationBins(int durationBins) { this.durationBins = durationBins; }
+}

--- a/src/main/java/vv/pms/presentation/Room.java
+++ b/src/main/java/vv/pms/presentation/Room.java
@@ -1,0 +1,52 @@
+package vv.pms.presentation;
+
+import jakarta.persistence.*;
+import vv.pms.availability.Availability;
+
+@Entity
+@Table(name = "rooms")
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    // 5 x 16 matrix (Mon–Fri, 30-min bins 08:00–16:00)
+    @Convert(converter = Availability.MatrixConverter.class)
+    @Column(columnDefinition = "TEXT")
+    private Boolean[][] availability;
+
+    public Room() {
+    }
+
+    public Room(String name) {
+        this.name = name;
+        this.availability = defaultFullAvailability();
+    }
+
+    public Room(String name, Boolean[][] availability) {
+        this.name = name;
+        this.availability = availability;
+    }
+
+    private Boolean[][] defaultFullAvailability() {
+        Boolean[][] matrix = new Boolean[5][16];
+        for (int d = 0; d < 5; d++) {
+            for (int t = 0; t < 16; t++) {
+                matrix[d][t] = Boolean.TRUE; // by default, rooms are available everywhere
+            }
+        }
+        return matrix;
+    }
+
+    public Long getId() { return id; }
+    public String getName() { return name; }
+    public Boolean[][] getAvailability() { return availability; }
+
+    public void setId(Long id) { this.id = id; }
+    public void setName(String name) { this.name = name; }
+    public void setAvailability(Boolean[][] availability) { this.availability = availability; }
+}

--- a/src/main/java/vv/pms/presentation/RoomService.java
+++ b/src/main/java/vv/pms/presentation/RoomService.java
@@ -1,0 +1,59 @@
+package vv.pms.presentation;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import vv.pms.presentation.internal.RoomRepository;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class RoomService {
+
+    private final RoomRepository repository;
+
+    public RoomService(RoomRepository repository) {
+        this.repository = repository;
+    }
+
+    public Room createRoom(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Room name is required");
+        }
+        if (repository.existsByNameIgnoreCase(name.trim())) {
+            throw new IllegalArgumentException("Room with that name already exists");
+        }
+        Room room = new Room(name.trim());
+        return repository.save(room);
+    }
+
+    public Room updateRoom(Long id, String name) {
+        Room room = repository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Room not found: " + id));
+        String cleaned = name == null ? "" : name.trim();
+        if (cleaned.isBlank()) {
+            throw new IllegalArgumentException("Room name is required");
+        }
+        if (!cleaned.equalsIgnoreCase(room.getName())
+                && repository.existsByNameIgnoreCase(cleaned)) {
+            throw new IllegalArgumentException("Room with that name already exists");
+        }
+        room.setName(cleaned);
+        return repository.save(room);
+    }
+
+    public void deleteRoom(Long id) {
+        repository.deleteById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Room> getAllRooms() {
+        return repository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Room getRoomById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Room not found: " + id));
+    }
+}

--- a/src/main/java/vv/pms/presentation/internal/PresentationSlotRepository.java
+++ b/src/main/java/vv/pms/presentation/internal/PresentationSlotRepository.java
@@ -1,0 +1,14 @@
+package vv.pms.presentation.internal;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import vv.pms.presentation.PresentationSlot;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PresentationSlotRepository extends JpaRepository<PresentationSlot, Long> {
+
+    Optional<PresentationSlot> findByProjectId(Long projectId);
+
+    List<PresentationSlot> findByRoomId(Long roomId);
+}

--- a/src/main/java/vv/pms/presentation/internal/RoomRepository.java
+++ b/src/main/java/vv/pms/presentation/internal/RoomRepository.java
@@ -1,0 +1,9 @@
+package vv.pms.presentation.internal;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import vv.pms.presentation.Room;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+
+    boolean existsByNameIgnoreCase(String name);
+}

--- a/src/main/java/vv/pms/ui/AvailabilityController.java
+++ b/src/main/java/vv/pms/ui/AvailabilityController.java
@@ -61,24 +61,28 @@ public class AvailabilityController {
     }
 
     private String[] generateTimeLabels() {
-        String[] labels = new String[32];
-        int startHour = 8;
-        int startMin = 0;
+        String[] labels = new String[16];
+        int hour = 8;
+        int min = 0;
 
-        for (int i = 0; i < 32; i++) {
-            int endMin = startMin + 15;
-            int endHour = startHour;
-            if (endMin == 60) {
-                endMin = 0;
+        for (int i = 0; i < 16; i++) {
+            int endMin = min + 30;
+            int endHour = hour;
+
+            if (endMin >= 60) {
+                endMin -= 60;
                 endHour++;
             }
-            labels[i] = String.format("%02d:%02d-%02d:%02d", startHour, startMin, endHour, endMin);
-            startMin += 15;
-            if (startMin == 60) {
-                startMin = 0;
-                startHour++;
+
+            labels[i] = String.format("%02d:%02d-%02d:%02d", hour, min, endHour, endMin);
+
+            min += 30;
+            if (min >= 60) {
+                min -= 60;
+                hour++;
             }
         }
+
         return labels;
     }
 }

--- a/src/main/java/vv/pms/ui/PresentationController.java
+++ b/src/main/java/vv/pms/ui/PresentationController.java
@@ -1,0 +1,128 @@
+package vv.pms.ui;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import vv.pms.presentation.PresentationService;
+import vv.pms.presentation.Room;
+import vv.pms.presentation.RoomService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Controller
+@RequestMapping("/presentations")
+public class PresentationController {
+
+    private final PresentationService presentationService;
+    private final RoomService roomService;
+
+    public PresentationController(PresentationService presentationService,
+                                  RoomService roomService) {
+        this.presentationService = presentationService;
+        this.roomService = roomService;
+    }
+
+    @GetMapping
+    public String showPresentations(HttpSession session, Model model,
+                                    @RequestParam(value = "error", required = false) String error) {
+
+        Object roleObj = session.getAttribute("currentUserRole");
+        if (roleObj == null) {
+            return "redirect:/login";
+        }
+
+        model.addAttribute("currentUserName", session.getAttribute("currentUserName"));
+        model.addAttribute("currentUserRole", session.getAttribute("currentUserRole"));
+
+
+        List<Room> rooms = roomService.getAllRooms();
+        var rows = presentationService.buildPresentationRows();
+
+        Map<Long, List<PresentationService.SlotOption>> slotOptionsByProject = new HashMap<>();
+        for (var row : rows) {
+            Long roomId = row.roomId();
+            if (roomId != null) {
+                slotOptionsByProject.put(
+                        row.projectId(),
+                        presentationService.getAvailableSlots(row.projectId(), roomId)
+                );
+            } else if (!rooms.isEmpty()) {
+                Long defaultRoomId = rooms.get(0).getId();
+                slotOptionsByProject.put(
+                        row.projectId(),
+                        presentationService.getAvailableSlots(row.projectId(), defaultRoomId)
+                );
+            }
+        }
+
+        model.addAttribute("rooms", rooms);
+        model.addAttribute("rows", rows);
+        model.addAttribute("slotOptionsByProject", slotOptionsByProject);
+        model.addAttribute("error", error);
+
+        return "presentations";
+    }
+
+    // ---------- Rooms ----------
+
+    @PostMapping("/rooms/add")
+    public String addRoom(@RequestParam("name") String name) {
+        try {
+            roomService.createRoom(name);
+            return "redirect:/presentations";
+        } catch (Exception e) {
+            return "redirect:/presentations?error=" + e.getMessage().replace(" ", "%20");
+        }
+    }
+
+    @PostMapping("/rooms/update")
+    public String updateRoom(@RequestParam("id") Long id,
+                             @RequestParam("name") String name) {
+        try {
+            roomService.updateRoom(id, name);
+            return "redirect:/presentations";
+        } catch (Exception e) {
+            return "redirect:/presentations?error=" + e.getMessage().replace(" ", "%20");
+        }
+    }
+
+    @PostMapping("/rooms/delete")
+    public String deleteRoom(@RequestParam("id") Long id) {
+        roomService.deleteRoom(id);
+        return "redirect:/presentations";
+    }
+
+    // ---------- Assign / Unassign ----------
+
+    @PostMapping("/assign")
+    public String assign(@RequestParam("projectId") Long projectId,
+                         @RequestParam("roomId") Long roomId,
+                         @RequestParam("slotKey") String slotKey) {
+        try {
+            String[] parts = slotKey.split("-");
+            int dayIndex = Integer.parseInt(parts[0]);
+            int startBinIndex = Integer.parseInt(parts[1]);
+            presentationService.assignPresentation(projectId, roomId, dayIndex, startBinIndex);
+            return "redirect:/presentations";
+        } catch (Exception e) {
+            return "redirect:/presentations?error=" + e.getMessage().replace(" ", "%20");
+        }
+    }
+
+    @PostMapping("/unassign")
+    public String unassign(@RequestParam("projectId") Long projectId) {
+        presentationService.unassignPresentation(projectId);
+        return "redirect:/presentations";
+    }
+
+    // ---------- Best-effort auto assignment ----------
+
+    @PostMapping("/auto")
+    public String autoAssign() {
+        presentationService.runBestEffortAllocation();
+        return "redirect:/presentations";
+    }
+}

--- a/src/main/resources/templates/availability.html
+++ b/src/main/resources/templates/availability.html
@@ -46,7 +46,7 @@
                 <tbody>
                 <tr th:each="timeLabel, i : ${timeSlots}">
 
-                    <td th:text="${timeLabel}" class="fw-bold">08:00</td>
+                    <td th:text="${timeLabel}" class="fw-bold"></td>
 
                     <td th:each="day, j : ${days}"
                         th:with="isAvailable=*{timeslots[__${j.index}__][__${i.index}__]}"
@@ -56,8 +56,8 @@
                                 th:name="|timeslots[${j.index}][${i.index}]|">
 
                             <option value="false" th:selected="${!isAvailable}">&#10060;</option>
-
                             <option value="true" th:selected="${isAvailable}">&#9989;</option>
+
                         </select>
                     </td>
                 </tr>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -20,6 +20,14 @@
                    style="margin-right:8px;"
                    th:if="${currentUserRole == 'STUDENT' or currentUserRole == 'PROFESSOR'}">Availability</a>
 
+
+                <a th:href="@{/presentations}"
+                   style="margin-right:8px;"
+                   th:if="${currentUserRole == 'COORDINATOR'}">
+                    Presentations
+                </a>
+
+
             </div>
 
             <div>

--- a/src/main/resources/templates/presentations.html
+++ b/src/main/resources/templates/presentations.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Presentations</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div th:replace="fragments/header :: header"></div>
+
+<div class="container mt-4">
+
+  <h1>Presentations</h1>
+
+  <div th:if="${error}" class="alert alert-danger mt-2" th:text="${error}"></div>
+
+  <!-- =======================
+       Section 1: Rooms
+       ======================= -->
+  <section class="mt-4">
+    <h2>Rooms</h2>
+
+    <form th:action="@{/presentations/rooms/add}" method="post" class="row g-2 align-items-center mb-3">
+      <div class="col-auto">
+        <label for="roomName" class="col-form-label">Room name:</label>
+      </div>
+      <div class="col-auto">
+        <input id="roomName" name="name" type="text" class="form-control" required>
+      </div>
+      <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Add Room</button>
+      </div>
+    </form>
+
+    <table class="table table-bordered table-sm align-middle">
+      <thead class="table-light">
+      <tr>
+        <th style="width:50%;">Room Name</th>
+        <th style="width:50%;">Actions</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr th:each="room : ${rooms}">
+        <td>
+          <form th:action="@{/presentations/rooms/update}" method="post" class="d-flex gap-2">
+            <input type="hidden" name="id" th:value="${room.id}">
+            <input type="text" name="name" class="form-control" th:value="${room.name}" required>
+            <button type="submit" class="btn btn-sm btn-secondary">Update</button>
+          </form>
+        </td>
+        <td>
+          <form th:action="@{/presentations/rooms/delete}" method="post"
+                onsubmit="return confirm('Delete this room?');">
+            <input type="hidden" name="id" th:value="${room.id}">
+            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+          </form>
+        </td>
+      </tr>
+      <tr th:if="${#lists.isEmpty(rooms)}">
+        <td colspan="2" class="text-muted text-center">No rooms created yet.</td>
+      </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- =======================
+       Section 2: Room Assignment
+       ======================= -->
+  <section class="mt-5">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2 class="mb-0">Room Assignment</h2>
+      <form th:action="@{/presentations/auto}" method="post">
+        <button type="submit" class="btn btn-outline-primary">
+          Assign Rooms Automatically
+        </button>
+      </form>
+    </div>
+
+    <table class="table table-bordered table-hover align-middle">
+      <thead class="table-light">
+      <tr>
+        <th>Project</th>
+        <th>Professor</th>
+        <th>Students</th>
+        <th style="width:180px;">Room</th>
+        <th style="width:260px;">Time</th>
+        <th style="width:180px;">Actions</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr th:each="row : ${rows}">
+        <td th:text="${row.projectTitle}"></td>
+        <td th:text="${row.professorName}"></td>
+        <td th:text="${row.studentNames}"></td>
+
+        <td>
+          <form th:action="@{/presentations/assign}" method="post" class="row g-2 align-items-center">
+            <input type="hidden" name="projectId" th:value="${row.projectId}">
+
+            <div class="col-12">
+              <select name="roomId" class="form-select form-select-sm" required>
+                <option th:each="room : ${rooms}"
+                        th:value="${room.id}"
+                        th:text="${room.name}"
+                        th:selected="${row.roomId} != null ? ${room.id} == ${row.roomId} : false">
+                </option>
+              </select>
+            </div>
+
+            <div class="col-12 mt-1">
+              <select name="slotKey" class="form-select form-select-sm" required>
+                <option th:each="opt : ${slotOptionsByProject[row.projectId]}"
+                        th:value="|${opt.dayIndex()}-${opt.startBinIndex()}|"
+                        th:text="${opt.label}">
+                </option>
+                <option th:if="${#lists.isEmpty(slotOptionsByProject[row.projectId])}"
+                        disabled>
+                  No available slots
+                </option>
+              </select>
+            </div>
+
+            <div class="col-12 mt-1">
+              <button type="submit" class="btn btn-sm btn-primary">
+                <span th:text="${row.slotLabel != null} ? 'Update' : 'Assign'">Assign</span>
+              </button>
+            </div>
+          </form>
+        </td>
+
+        <td>
+          <span th:text="${row.slotLabel != null ? row.slotLabel : 'Not assigned'}"></span>
+        </td>
+
+        <td>
+          <form th:if="${row.slotLabel != null}"
+                th:action="@{/presentations/unassign}" method="post"
+                onsubmit="return confirm('Unassign this presentation slot?');">
+            <input type="hidden" name="projectId" th:value="${row.projectId}">
+            <button type="submit" class="btn btn-sm btn-outline-danger">Unassign</button>
+          </form>
+          <span th:if="${row.slotLabel == null}" class="text-muted">No slot</span>
+        </td>
+      </tr>
+
+      <tr th:if="${#lists.isEmpty(rows)}">
+        <td colspan="6" class="text-muted text-center">
+          No projects with allocations and students to schedule.
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </section>
+
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
##  New Features

###  **Coordinator Presentation Scheduling**
- New `/presentations` dashboard for scheduling oral presentations
- Displays all projects, rooms, assigned slots, and availability
- Allows coordinators to manage presentation logistics end to end

###  **Room Management**
- Add new rooms  
- Update room names  
- Delete rooms  
- Automatically refreshes presentation grid on each change  
- Room info persisted through `RoomService`

###  **Slot Assignment**
- Assign a project to a specific **day/time bin** within a room
- Unassign presentations if times change
- Slot availability dynamically computed using:
  - project constraints  
  - room constraints  
  - existing bookings  

###  **Best-Effort Auto Allocation**
- Coordinator can trigger automatic scheduling for all unassigned projects
- Uses `PresentationService.runBestEffortAllocation()`
- Prevents collisions and respects availability rules

---

##  UI & Data Enhancements

###  Presentation Grid Rendering
- Added `buildPresentationRows()` mapping logic
- Generates rows containing:
  - project info  
  - professor  
  - assigned room  
  - assigned slot  
  - slot options (if unassigned)

Closes #57 