### PR TITLE
Remove placeholder UI and add azure link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # 4th Year Project Management System
 A web-based system designed to manage 4th-year project topics, student applications, oral presentations, and final report submissions. This system streamlines project coordination for professors, students, and the 4th-year project coordinator.  
 
+## Project Hosted on Azure
+Project is hosted on azure and available at this link:
+https://sysc4806-lab5-erik-v2-gwhkcfeeckapb0e8.canadacentral-01.azurewebsites.net/home
+
 ## Milestone 3 Features
 
 - Enforce report submission endpoint + deadline enforcement https://github.com/ErikCald/SYSC4806-Project-TheVelocityVultures/issues/37  

--- a/src/main/resources/templates/coordinator.html
+++ b/src/main/resources/templates/coordinator.html
@@ -96,9 +96,6 @@
 
         <!-- No server submit required; handled client-side with mailto link -->
     </form>
-    <hr class="mt-5"/>
-    <h2 class="mt-4">Oral Presentation Room Allocation</h2>
-    <p class="text-muted">(Coming soon)</p>
 </div>
 
 <!-- Reminder Modal -->


### PR DESCRIPTION
Removed the header at the bottom of this page because it was instead built into a different page:
<img width="1470" height="845" alt="image" src="https://github.com/user-attachments/assets/99cd0ed7-17bc-4bfb-ba74-f465a929e1a9" />
